### PR TITLE
feat: Add support for multiple AI providers

### DIFF
--- a/lib/domains/ai/data/ai_repository_impl.dart
+++ b/lib/domains/ai/data/ai_repository_impl.dart
@@ -12,7 +12,7 @@ import 'client/google_generative_ai_client.dart';
 class AiRepositoryImpl implements AiRepository {
   final AiClient _client;
 
-  AiRepositoryImpl(String apiKey) : _client = GoogleGenerativeAiClient(apiKey);
+  AiRepositoryImpl(this._client);
 
   @override
   bool get isInitialized => _client.isInitialized;

--- a/lib/domains/ai/data/client/openai_client.dart
+++ b/lib/domains/ai/data/client/openai_client.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+
+import 'package:dart_openai/dart_openai.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_chat_desktop/domains/ai/entity/ai_entities.dart';
+
+import 'ai_client.dart';
+
+class OpenAiClient implements AiClient {
+  final String _apiKey;
+  bool _isInitialized = false;
+  Object? _initializationError;
+
+  @override
+  bool get isInitialized => _isInitialized;
+
+  @override
+  Object? get initializationError => _initializationError;
+
+  OpenAiClient(this._apiKey) {
+    initialize();
+  }
+
+  @override
+  bool initialize() {
+    if (_apiKey.isEmpty) {
+      _initializationError = 'OpenAI API key is missing.';
+      _isInitialized = false;
+      return false;
+    }
+    try {
+      OpenAI.apiKey = _apiKey;
+      _isInitialized = true;
+      return true;
+    } catch (e) {
+      _initializationError = "Failed to initialize OpenAI client: ${e.toString()}";
+      _isInitialized = false;
+      return false;
+    }
+  }
+
+  List<OpenAIChatCompletionChoiceMessageModel> _convertHistoryToOpenAIMessages(
+    List<AiContent> history,
+  ) {
+    return history.map((content) {
+      final role = content.role == AiContent.userRole
+          ? OpenAIChatMessageRole.user
+          : OpenAIChatMessageRole.assistant;
+
+      final textContent = content.parts.map((p) => p.text).join();
+
+      return OpenAIChatCompletionChoiceMessageModel(
+        role: role,
+        content: [
+          OpenAIChatCompletionChoiceMessageContentItemModel.text(textContent),
+        ],
+      );
+    }).toList();
+  }
+
+  @override
+  Stream<AiStreamChunk> getResponseStream(List<AiContent> content) {
+    if (!isInitialized) {
+      return Stream.error(Exception("OpenAI client not initialized. $_initializationError"));
+    }
+
+    final openAiMessages = _convertHistoryToOpenAIMessages(content);
+
+    try {
+      final stream = OpenAI.instance.chat.createStream(
+        model: "gpt-4-turbo",
+        messages: openAiMessages,
+      );
+
+      return stream.map((streamChatCompletion) {
+        final text = streamChatCompletion.choices.first.delta.content ?? '';
+        final isFinish = streamChatCompletion.choices.first.finishReason != null;
+        return AiStreamChunk(text: text, isFinish: isFinish);
+      }).transform(StreamTransformer.fromHandlers(
+        handleError: (error, stackTrace, sink) {
+          debugPrint("Error in OpenAI stream: $error");
+          sink.addError(Exception("Failed to get response from OpenAI: $error"));
+        },
+      ));
+    } catch (e) {
+      debugPrint("Error creating OpenAI stream: $e");
+      return Stream.error(Exception("Failed to create stream with OpenAI: $e"));
+    }
+  }
+
+  @override
+  Future<AiResponse> getResponse(
+    List<AiContent> content, {
+    List<AiTool>? tools,
+  }) async {
+     if (!isInitialized) {
+      throw Exception("OpenAI client not initialized. $_initializationError");
+    }
+
+    if (tools != null && tools.isNotEmpty) {
+      throw UnimplementedError("Tool usage is not implemented for the OpenAI client yet.");
+    }
+
+    final openAiMessages = _convertHistoryToOpenAIMessages(content);
+
+    try {
+      final chatCompletion = await OpenAI.instance.chat.create(
+        model: "gpt-4-turbo",
+        messages: openAiMessages,
+      );
+
+      final message = chatCompletion.choices.first.message;
+      final textResponse = message.content?.map((p) => p.text).join() ?? '';
+
+      final candidate = AiCandidate(
+        content: AiContent(role: AiContent.modelRole, parts: [AiPart(text: textResponse)]),
+        finishReason: _mapFinishReason(chatCompletion.choices.first.finishReason),
+      );
+
+      return AiResponse(candidates: [candidate]);
+
+    } catch (e) {
+      debugPrint("Error getting OpenAI response: $e");
+      throw Exception("Failed to get response from OpenAI: $e");
+    }
+  }
+
+  FinishReason _mapFinishReason(String? reason) {
+    switch (reason) {
+      case 'stop':
+        return FinishReason.stop;
+      case 'length':
+        return FinishReason.maxTokens;
+      case 'tool_calls':
+        return FinishReason.recitation; // Or a more appropriate mapping
+      case 'content_filter':
+        return FinishReason.safety;
+      default:
+        return FinishReason.other;
+    }
+  }
+}

--- a/lib/domains/ai/entity/ai_provider_type.dart
+++ b/lib/domains/ai/entity/ai_provider_type.dart
@@ -1,0 +1,5 @@
+/// Enum representing the supported AI providers.
+enum AIProviderType {
+  gemini,
+  openAI,
+}

--- a/lib/domains/settings/entity/ai_config.dart
+++ b/lib/domains/settings/entity/ai_config.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_chat_desktop/domains/ai/entity/ai_provider_type.dart';
+
+@immutable
+class AIConfig {
+  final AIProviderType selectedProvider;
+  final Map<AIProviderType, String> apiKeys;
+
+  const AIConfig({
+    this.selectedProvider = AIProviderType.gemini,
+    this.apiKeys = const {},
+  });
+
+  String? get currentApiKey => apiKeys[selectedProvider];
+
+  AIConfig copyWith({
+    AIProviderType? selectedProvider,
+    Map<AIProviderType, String>? apiKeys,
+  }) {
+    return AIConfig(
+      selectedProvider: selectedProvider ?? this.selectedProvider,
+      apiKeys: apiKeys ?? this.apiKeys,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'selectedProvider': selectedProvider.name,
+      'apiKeys': apiKeys.map((key, value) => MapEntry(key.name, value)),
+    };
+  }
+
+  factory AIConfig.fromMap(Map<String, dynamic> map) {
+    return AIConfig(
+      selectedProvider: AIProviderType.values.firstWhere(
+        (e) => e.name == map['selectedProvider'],
+        orElse: () => AIProviderType.gemini,
+      ),
+      apiKeys: Map<AIProviderType, String>.from(
+        (map['apiKeys'] as Map<String, dynamic>).map(
+          (key, value) => MapEntry(
+            AIProviderType.values.firstWhere((e) => e.name == key),
+            value as String,
+          ),
+        ),
+      ),
+    );
+  }
+
+  String toJson() => json.encode(toMap());
+
+  factory AIConfig.fromJson(String source) => AIConfig.fromMap(json.decode(source));
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is AIConfig &&
+        other.selectedProvider == selectedProvider &&
+        mapEquals(other.apiKeys, apiKeys);
+  }
+
+  @override
+  int get hashCode => selectedProvider.hashCode ^ apiKeys.hashCode;
+}

--- a/lib/domains/settings/repository/settings_repository.dart
+++ b/lib/domains/settings/repository/settings_repository.dart
@@ -1,11 +1,11 @@
+import '../entity/ai_config.dart';
 import '../entity/mcp_server_config.dart';
 
 /// Abstract repository for managing application settings.
 abstract class SettingsRepository {
-  // API Key
-  Future<String?> getApiKey();
-  Future<void> saveApiKey(String apiKey);
-  Future<void> clearApiKey();
+  // AI Configuration
+  Future<AIConfig> getAIConfig();
+  Future<void> saveAIConfig(AIConfig config);
 
   // MCP Server List
   Future<List<McpServerConfig>> getMcpServerList();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_chat_desktop/providers/settings_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -15,7 +14,8 @@ Future<void> main() async {
     final prefs = await SharedPreferences.getInstance();
 
     final initialSettingsRepo = SettingsRepositoryImpl(prefs);
-    final initialApiKey = await initialSettingsRepo.getApiKey();
+    // Load the full AI config instead of just the API key
+    final initialAIConfig = await initialSettingsRepo.getAIConfig();
     final initialServerList = await initialSettingsRepo.getMcpServerList();
 
     runApp(
@@ -26,7 +26,8 @@ Future<void> main() async {
             (ref) =>
                 SettingsRepositoryImpl(ref.watch(sharedPreferencesProvider)),
           ),
-          apiKeyProvider.overrideWith((ref) => initialApiKey),
+          // Override the new aiConfigProvider with the loaded value
+          aiConfigProvider.overrideWith((ref) => initialAIConfig),
           mcpServerListProvider.overrideWith((ref) => initialServerList),
         ],
         child: const MyApp(),

--- a/lib/presentation/widgets/api_key_section.dart
+++ b/lib/presentation/widgets/api_key_section.dart
@@ -1,38 +1,73 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_chat_desktop/domains/ai/entity/ai_provider_type.dart';
+import 'package:flutter_chat_desktop/domains/settings/entity/ai_config.dart';
 
 class ApiKeySection extends StatelessWidget {
-  final TextEditingController controller;
-  final String? currentApiKey;
+  final AIConfig config;
+  final TextEditingController apiKeyController;
+  final ValueChanged<AIProviderType?> onProviderChanged;
   final Function() onSave;
   final Function() onClear;
 
   const ApiKeySection({
     super.key,
-    required this.controller,
-    required this.currentApiKey,
+    required this.config,
+    required this.apiKeyController,
+    required this.onProviderChanged,
     required this.onSave,
     required this.onClear,
   });
 
+  String _getProviderName(AIProviderType provider) {
+    switch (provider) {
+      case AIProviderType.gemini:
+        return 'Gemini';
+      case AIProviderType.openAI:
+        return 'OpenAI';
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final providerName = _getProviderName(config.selectedProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'Gemini API Key',
-          style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.bold),
+        Text(
+          'AI Provider',
+          style: theme.textTheme.titleLarge,
+        ),
+        const SizedBox(height: 8.0),
+        // Dropdown for selecting the AI provider
+        DropdownButtonFormField<AIProviderType>(
+          value: config.selectedProvider,
+          items: AIProviderType.values.map((provider) {
+            return DropdownMenuItem<AIProviderType>(
+              value: provider,
+              child: Text(_getProviderName(provider)),
+            );
+          }).toList(),
+          onChanged: onProviderChanged,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            contentPadding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+          ),
+        ),
+        const SizedBox(height: 16.0),
+        Text(
+          '$providerName API Key',
+          style: theme.textTheme.titleLarge,
         ),
         const SizedBox(height: 8.0),
         TextField(
-          controller: controller,
+          controller: apiKeyController,
           obscureText: true,
-          decoration: const InputDecoration(
-            hintText: 'Enter your Gemini API Key',
-            border: OutlineInputBorder(),
-            suffixIcon: Icon(Icons.vpn_key),
+          decoration: InputDecoration(
+            hintText: 'Enter your $providerName API Key',
+            border: const OutlineInputBorder(),
+            suffixIcon: const Icon(Icons.vpn_key),
           ),
           onSubmitted: (_) => onSave(),
         ),
@@ -45,7 +80,7 @@ class ApiKeySection extends StatelessWidget {
               label: const Text('Save Key'),
               onPressed: onSave,
             ),
-            if (currentApiKey != null && currentApiKey!.isNotEmpty)
+            if (config.currentApiKey != null && config.currentApiKey!.isNotEmpty)
               TextButton.icon(
                 icon: const Icon(Icons.clear),
                 label: const Text('Clear Key'),
@@ -58,7 +93,7 @@ class ApiKeySection extends StatelessWidget {
         ),
         const SizedBox(height: 4.0),
         const Text(
-          'Stored locally.',
+          'Stored securely on your device.',
           style: TextStyle(
             fontSize: 12.0,
             fontStyle: FontStyle.italic,

--- a/lib/providers/ai_providers.dart
+++ b/lib/providers/ai_providers.dart
@@ -1,15 +1,42 @@
 import 'package:flutter_chat_desktop/domains/ai/data/ai_repository_impl.dart';
+import 'package:flutter_chat_desktop/domains/ai/data/client/ai_client.dart';
+import 'package:flutter_chat_desktop/domains/ai/data/client/google_generative_ai_client.dart';
+import 'package:flutter_chat_desktop/domains/ai/data/client/openai_client.dart';
+import 'package:flutter_chat_desktop/domains/ai/entity/ai_provider_type.dart';
 import 'package:flutter_chat_desktop/domains/ai/repository/ai_repository.dart';
 import 'package:flutter_chat_desktop/providers/settings_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Provider for the AI Repository.
-/// It depends on the API key from the settings providers.
+/// This provider is responsible for creating the correct AI client based on
+/// the user's settings and providing it to the AI repository.
 final aiRepositoryProvider = Provider<AiRepository?>((ref) {
-  final apiKey = ref.watch(apiKeyProvider);
-  if (apiKey != null && apiKey.isNotEmpty) {
-    return AiRepositoryImpl(apiKey);
+  // Watch the AI configuration from the settings
+  final aiConfig = ref.watch(aiConfigProvider);
+
+  // Get the API key for the currently selected provider
+  final apiKey = aiConfig.currentApiKey;
+
+  // If there's no API key for the selected provider, return null
+  if (apiKey == null || apiKey.isEmpty) {
+    return null;
   }
-  // Return null if API key is not available
-  return null;
+
+  // Create the appropriate client based on the selected provider
+  AiClient client;
+  switch (aiConfig.selectedProvider) {
+    case AIProviderType.gemini:
+      client = GoogleGenerativeAiClient(apiKey);
+      break;
+    case AIProviderType.openAI:
+      client = OpenAiClient(apiKey);
+      break;
+    // Default case to ensure we always have a client if a new provider is added
+    default:
+      // Or return null if you want to disable AI features for unsupported providers
+      throw Exception('Unsupported AI provider: ${aiConfig.selectedProvider}');
+  }
+
+  // Return the repository implementation with the selected client
+  return AiRepositoryImpl(client);
 });

--- a/lib/providers/settings_providers.dart
+++ b/lib/providers/settings_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_chat_desktop/domains/settings/entity/ai_config.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
@@ -16,40 +17,27 @@ const _uuid = Uuid();
 /// the state providers to reflect changes in the application state.
 class SettingsService {
   final SettingsRepository _repository;
-  final StateController<String?> _apiKeyNotifier;
+  final StateController<AIConfig> _aiConfigNotifier;
   final StateController<List<McpServerConfig>> _mcpServerListNotifier;
 
   SettingsService({
     required SettingsRepository repository,
-    required StateController<String?> apiKeyNotifier,
+    required StateController<AIConfig> aiConfigNotifier,
     required StateController<List<McpServerConfig>> mcpServerListNotifier,
-  }) : _repository = repository,
-       _apiKeyNotifier = apiKeyNotifier,
-       _mcpServerListNotifier = mcpServerListNotifier;
+  })  : _repository = repository,
+        _aiConfigNotifier = aiConfigNotifier,
+        _mcpServerListNotifier = mcpServerListNotifier;
 
-  /// Saves the API key to the repository and updates the state.
-  Future<void> saveApiKey(String apiKey) async {
+  /// Saves the AI config to the repository and updates the state.
+  Future<void> saveAIConfig(AIConfig config) async {
     try {
-      await _repository.saveApiKey(apiKey);
+      await _repository.saveAIConfig(config);
       // Update the application state
-      _apiKeyNotifier.state = apiKey;
-      debugPrint("SettingsService: API Key saved.");
+      _aiConfigNotifier.state = config;
+      debugPrint("SettingsService: AI Config saved.");
     } catch (e) {
-      debugPrint("SettingsService: Error saving API key: $e");
+      debugPrint("SettingsService: Error saving AI Config: $e");
       rethrow; // Allow UI layer to handle error display
-    }
-  }
-
-  /// Clears the API key from the repository and updates the state.
-  Future<void> clearApiKey() async {
-    try {
-      await _repository.clearApiKey();
-      // Update the application state
-      _apiKeyNotifier.state = null;
-      debugPrint("SettingsService: API Key cleared.");
-    } catch (e) {
-      debugPrint("SettingsService: Error clearing API key: $e");
-      rethrow;
     }
   }
 
@@ -178,8 +166,8 @@ final settingsRepositoryProvider = Provider<SettingsRepository>((ref) {
   return SettingsRepositoryImpl(prefs);
 });
 
-/// Holds the current API Key string (nullable).
-final apiKeyProvider = StateProvider<String?>((ref) => null);
+/// Holds the current AI Configuration.
+final aiConfigProvider = StateProvider<AIConfig>((ref) => const AIConfig());
 
 /// Holds the list of configured MCP servers. This is the source of truth for UI and MCP connection sync.
 final mcpServerListProvider = StateProvider<List<McpServerConfig>>((ref) => []);
@@ -188,13 +176,13 @@ final mcpServerListProvider = StateProvider<List<McpServerConfig>>((ref) => []);
 final settingsServiceProvider = Provider<SettingsService>((ref) {
   // Get dependencies from other providers
   final repository = ref.watch(settingsRepositoryProvider);
-  final apiKeyNotifier = ref.watch(apiKeyProvider.notifier);
+  final aiConfigNotifier = ref.watch(aiConfigProvider.notifier);
   final mcpServerListNotifier = ref.watch(mcpServerListProvider.notifier);
 
   // Create service with injected dependencies
   return SettingsService(
     repository: repository,
-    apiKeyNotifier: apiKeyNotifier,
+    aiConfigNotifier: aiConfigNotifier,
     mcpServerListNotifier: mcpServerListNotifier,
   );
 });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_svg: ^2.0.17
   mcp_dart: ^0.3.6
   google_generative_ai: ^0.4.7
+  dart_openai: ^5.1.0
   flutter_riverpod: ^2.6.1
   http: ^1.3.0
   flutter_markdown: ^0.7.7


### PR DESCRIPTION
This commit introduces a major feature that allows users to select from multiple AI providers (currently Gemini and OpenAI).

Key changes include:
- Introduced a generic `AiClient` interface to abstract the AI service layer.
- Refactored the settings management to use a new `AIConfig` entity, allowing for provider selection and per-provider API keys.
- Updated the Settings screen UI with a dropdown to switch between AI providers and manage their API keys.
- Added an `OpenAiClient` implementation using the `dart_openai` package.
- The application now dynamically selects the appropriate AI client based on user settings.