### PR TITLE
fix: Resolve final compilation errors and inconsistencies

### DIFF
--- a/lib/domains/ai/data/client/openai_client.dart
+++ b/lib/domains/ai/data/client/openai_client.dart
@@ -9,13 +9,13 @@ import 'ai_client.dart';
 class OpenAiClient implements AiClient {
   final String _apiKey;
   bool _isInitialized = false;
-  Object? _initializationError;
+  String? _initializationError;
 
   @override
   bool get isInitialized => _isInitialized;
 
   @override
-  Object? get initializationError => _initializationError;
+  String? get initializationError => _initializationError;
 
   OpenAiClient(this._apiKey) {
     initialize();

--- a/lib/providers/chat_providers.dart
+++ b/lib/providers/chat_providers.dart
@@ -183,7 +183,7 @@ class ChatNotifier extends StateNotifier<ChatState> {
               if (mounted && state.isLoading) _setLoading(false);
               return;
             }
-            fullResponseBuffer.write(chunk.textDelta);
+            fullResponseBuffer.write(chunk.text);
             lastAiMessage = lastAiMessage.copyWith(
               text: fullResponseBuffer.toString(),
             );


### PR DESCRIPTION
This commit addresses two final compilation errors reported by the user after the major UI and feature update.

- Fixed an error in `ChatNotifier` where `chunk.textDelta` was used instead of the renamed `chunk.text`.
- Corrected a type mismatch in `OpenAiClient` where `initializationError` was implemented as `Object?` instead of the required `String?` from the `AiClient` interface.

With these fixes, the application should now compile and run as expected.