### PR TITLE
fix: Correctly extract text from AiPart in OpenAiClient

### DIFF
--- a/lib/domains/ai/data/client/openai_client.dart
+++ b/lib/domains/ai/data/client/openai_client.dart
@@ -47,7 +47,8 @@ class OpenAiClient implements AiClient {
           ? OpenAIChatMessageRole.user
           : OpenAIChatMessageRole.assistant;
 
-      final textContent = content.parts.map((p) => p.text).join();
+      final textContent =
+          content.parts.whereType<AiTextPart>().map((p) => p.text).join();
 
       return OpenAIChatCompletionChoiceMessageModel(
         role: role,


### PR DESCRIPTION
This commit fixes a bug where the OpenAiClient was attempting to access a `.text` property on a generic `AiPart` object, which caused a compilation error.

The implementation has been corrected to filter for parts of type `AiTextPart` before mapping to text, ensuring that the text is extracted safely and correctly. This resolves the user-reported runtime error.